### PR TITLE
feat: 🎸 update the height of input fields and buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6905,8 +6905,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -6927,14 +6926,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6949,20 +6946,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -7079,8 +7073,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -7092,7 +7085,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7107,7 +7099,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -7115,14 +7106,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -7141,7 +7130,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -7222,8 +7210,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -7235,7 +7222,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -7321,8 +7307,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -7358,7 +7343,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7378,7 +7362,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7422,14 +7405,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},

--- a/src/components/buttons/_button-mixins.scss
+++ b/src/components/buttons/_button-mixins.scss
@@ -13,7 +13,7 @@
 $vanilla-button-padding: vanilla-px-to-em(16) !default;
 
 // Config
-$_height: vanilla-px-to-em(40 - 2);
+$_height: vanilla-px-to-em(44 - 2);
 $_border-radius: $vanilla-component-border-radius;
 
 $_button_color-bg-normal: $vanilla-color-component-normal;

--- a/src/components/inputs/_input-mixins.scss
+++ b/src/components/inputs/_input-mixins.scss
@@ -15,7 +15,7 @@
 /// @access public
 @mixin vanilla-field-base() {
   // Config
-  $_height: vanilla-px-to-em(40px);
+  $_height: vanilla-px-to-em(44px);
   $_border-color-normal: $vanilla-color-grey7;
   //
 
@@ -313,7 +313,7 @@
 @mixin vanilla-field-dropdown-button() {
   @include vanilla-field-base();
 
-  line-height: vanilla-px-to-em(40px);
+  line-height: vanilla-px-to-em(44 - 2);
   padding: 0 0 0 1rem;
   cursor: pointer;
   position: relative;
@@ -321,7 +321,7 @@
   background-color: $vanilla-color-white;
 
   &:after {
-    @include vanilla-icon($_glyph: "\F078", $_space: vanilla-px-to-em(40px));
+    @include vanilla-icon($_glyph: "\F078", $_space: vanilla-px-to-em(44 - 2));
 
     float: right;
     background-color: inherit;
@@ -347,7 +347,7 @@
     display: block;
     padding: 0 1rem;
     cursor: pointer;
-    line-height: vanilla-px-to-em(40px);
+    line-height: vanilla-px-to-em(44px);
 
     &:hover {
       background-color: $vanilla-color-component-normal;
@@ -360,7 +360,7 @@
     opacity: 0;
   }
 
-  line-height: vanilla-px-to-em(40px);
+  line-height: vanilla-px-to-em(44px);
 
   input {
     position: absolute;


### PR DESCRIPTION
 The input base mixin now uses a height of 44px. Buttons and the
dropdown component have also been updated to match the new height (with
respect to the 1px top and bottom borders)

BREAKING CHANGE: Any implementation relying on the input field base, buttons,  or the
dropdown button to have a height of exactly 40px (2.5em) could
potentially break

Issues: #5