### PR TITLE
feat: 🎸 update input field error indicator

### DIFF
--- a/src/components/inputs/_input-mixins.scss
+++ b/src/components/inputs/_input-mixins.scss
@@ -74,7 +74,7 @@
 ///
 /// @access public
 @mixin vanilla-text-field--error() {
-  $_border-bottom: vanilla-px-to-em(4) solid $vanilla-color-red;
+  $_border-bottom: vanilla-px-to-em(2) solid $vanilla-color-red;
 
   border-bottom: $_border-bottom;
   &:focus,
@@ -89,8 +89,9 @@
 /// @access public
 @mixin vanilla-text-field-notice() {
   display: block;
+  line-height: 1;
   font-size: vanilla-px-to-em(14);
-  margin-top: vanilla-px-to-em(1);
+  margin-top: vanilla-px-to-em(8);
 }
 
 /// Style that can be added to erroneous text field notice
@@ -105,9 +106,9 @@
 /// @access public
 @mixin vanilla-field-label() {
   display: block;
-
+  line-height: 1;
   margin-top: $vanilla-base-size;
-  margin-bottom: vanilla-px-to-em(1px);
+  margin-bottom: vanilla-px-to-em(8);
 
   font-size: vanilla-px-to-em(16px);
   font-weight: 500;


### PR DESCRIPTION
The input field notice error gets a 2px border instead of 4px. The
margins of both the label and the field field notice are also adjusted

Issues: #6