### PR TITLE
fix(ghost-buttons): fix disabled state colors

### DIFF
--- a/src/components/buttons/_button-mixins.scss
+++ b/src/components/buttons/_button-mixins.scss
@@ -23,6 +23,7 @@ $_button_color-bg-pressed: $vanilla-color-component-pressed;
 $_button_color-bg-focus: $vanilla-color-component-selected;
 $_button_disabled-color-dark: $vanilla-color-component-disabled-dark;
 $_button_disabled-color-light: $vanilla-color-component-disabled-light;
+$_ghost-button_disabled-opacity: 0.5;
 //
 
 /// Mixes in button styles
@@ -191,8 +192,8 @@ $_button_disabled-color-light: $vanilla-color-component-disabled-light;
   }
   &[disabled] {
     background-color: transparent;
-    border-color: $_button_disabled-color-dark;
-    color: $_button_disabled-color-dark;
+    border-color: rgba($vanilla-color-white, $_ghost-button_disabled-opacity);
+    color:  rgba($vanilla-color-white, $_ghost-button_disabled-opacity);
   }
 }
 
@@ -214,8 +215,8 @@ $_button_disabled-color-light: $vanilla-color-component-disabled-light;
   }
   &[disabled] {
     background-color: transparent;
-    border-color: $_button_disabled-color-dark;
-    color: $_button_disabled-color-dark;
+    border-color: rgba($vanilla-color-grey2, $_ghost-button_disabled-opacity);
+    color:  rgba($vanilla-color-grey2, $_ghost-button_disabled-opacity);
   }
 }
 

--- a/src/components/buttons/ghost-light.md
+++ b/src/components/buttons/ghost-light.md
@@ -45,7 +45,7 @@ This will create <i>.my-button-class</i> as well as <i>.my-button-class-ghost</i
 
 ## Disabled state
 ```html
-<div class="pl-purple-bg">
+<div class="pl-blue-bg">
     <button class="sdv-button sdv-button-ghost-light" disabled>Ghost button</button>
 </div>
 ```

--- a/src/preview-frame-only.scss
+++ b/src/preview-frame-only.scss
@@ -26,6 +26,13 @@ $vanilla-font-awesome-inc-path: "https://sebgroup.github.io/vanilla-pattern-libr
   text-align: center;
 }
 
+.pl-blue-bg {
+  background-color: $vanilla-color-blue;
+  padding: 2rem;
+  width: 100%;
+  text-align: center;
+}
+
 .pl-yellow-bg {
   background-color: $vanilla-color-yellow;
   padding: 2rem;


### PR DESCRIPTION
Disabled ghost buttons are no longer grey. Instead, they retain their acitve color, but at 50%
opacity.

fix #36