### PR TITLE
feat(slideout): add :target pseudo class to slideout

### DIFF
--- a/src/components/modals/_modal-mixins.scss
+++ b/src/components/modals/_modal-mixins.scss
@@ -1,4 +1,3 @@
-
 ////
 /// @group Component mixins
 /// @author SEB Design Library
@@ -15,7 +14,8 @@
   background-color: transparent;
   width: 100vw;
   height: 100vh;
-  .-active & {
+  .-sdv-modal-active &,
+  :target & {
     background-color: $background-color;
     visibility: visible;
   }

--- a/src/components/modals/_slideout-mixins.scss
+++ b/src/components/modals/_slideout-mixins.scss
@@ -2,11 +2,11 @@
 /// @group Component mixins
 /// @author SEB Design Library
 ////
-@import '../../variables';
+@import "../../variables";
 @import "../../utilities";
-@import '../buttons/button-mixins';
-@import 'node_modules/include-media/dist/include-media';
-@import '../../mixins';
+@import "../buttons/button-mixins";
+@import "node_modules/include-media/dist/include-media";
+@import "../../mixins";
 
 ///
 /// @access public
@@ -34,7 +34,8 @@
       transform: translate3d(-100%, 0, 0);
     }
   }
-  &.-active {
+  &.-sdv-modal-active,
+  &:target {
     visibility: visible;
     transition: visibility 0s 0s;
     #{$__module}__container {
@@ -51,7 +52,7 @@
     z-index: 1;
     transition: transform 0.3s ease-in-out;
 
-    @include media('<=tablet') {
+    @include media("<=tablet") {
       width: 100%;
     }
   }

--- a/src/components/modals/slideout.md
+++ b/src/components/modals/slideout.md
@@ -2,7 +2,7 @@
 title: Slideout
 componentid: component-slideout
 variantid: normal
-guid: component-slideout-modal-normal
+guid: component-slideout-normal
 ---
 
 # Usage
@@ -10,7 +10,7 @@ guid: component-slideout-modal-normal
 Import classes:
 
 ```scss
-@import '~@sebgroup/vanilla/src/components/modals/slideout';
+@import "~@sebgroup/vanilla/src/components/modals/slideout";
 ```
 
 Use them in your template:
@@ -20,24 +20,24 @@ Use them in your template:
 <div class="sdv-slideout sdv-slideout--left">...</div>
 ```
 
-To activate the modal, add the `-active` modifier:
+To activate the modal, add the `-sdv-modal-active` modifier:
 
 ```html
-<div class="sdv-slideout sdv-slideout--right -active">
+<div class="sdv-slideout sdv-slideout--right -sdv-modal-active">
   ...
   <div class="sdv-modal-backdrop"></div>
 </div>
 ```
 
-Please note - the backdrop element has to be a child of the modal, like above (since it depends on its parent's -active class)
+Please note - the backdrop element has to be a child of the modal, like above (since it depends on its parent's -sdv-modal-active class)
 
 ---
 
 You can also use the mixins:
 
 ```scss
-@import '~@sebgroup/vanilla/src/components/modals/slideout-mixins';
-@import '~@sebgroup/vanilla/src/components/modals/modal-mixins';
+@import "~@sebgroup/vanilla/src/components/modals/slideout-mixins";
+@import "~@sebgroup/vanilla/src/components/modals/modal-mixins";
 
 .my-modal-class {
   @include vanilla-slideout();
@@ -65,7 +65,7 @@ To override them use the media mixin from the 'include-media' package. For examp
 ```scss
 .sdv-slideout {
   &__container {
-    @include media('>=tablet', '<desktop') {
+    @include media(">=tablet", "<desktop") {
       width: 50%;
     }
   }
@@ -77,7 +77,7 @@ To override them use the media mixin from the 'include-media' package. For examp
 ## Right
 
 ```html
-<div class="sdv-slideout sdv-slideout--right -active">
+<div class="sdv-slideout sdv-slideout--right -sdv-modal-active">
   <div class="sdv-slideout__container">
     <header class="sdv-slideout__header">
       <h3 class="sdv-slideout__heading">Modal Heading</h3>
@@ -92,6 +92,49 @@ To override them use the media mixin from the 'include-media' package. For examp
   </div>
   <div class="sdv-modal-backdrop"></div>
 </div>
+```
+
+
+## Left
+
+```html
+<div class="sdv-slideout sdv-slideout--left -sdv-modal-active">
+  <div class="sdv-slideout__container">
+    <header class="sdv-slideout__header">
+      <h3 class="sdv-slideout__heading">Modal Heading</h3>
+      <button class="sdv-slideout__close">
+        <i class="fal fa-times"></i>
+      </button>
+    </header>
+    <div class="sdv-slideout__content">
+      <h4>Modal Content</h4>
+      <p>Lorem ipsum dolor sit amet</p>
+    </div>
+  </div>
+  <div class="sdv-modal-backdrop"></div>
+</div>
+```
+
+## Interactive left
+
+```html
+<div class="sdv-slideout sdv-slideout--right" id="slideout">
+  <div class="sdv-slideout__container">
+    <header class="sdv-slideout__header">
+      <h3 class="sdv-slideout__heading">Modal Heading</h3>
+      <button class="sdv-slideout__close">
+        <i class="fal fa-times"></i>
+      </button>
+    </header>
+    <div class="sdv-slideout__content">
+      <h4>Modal Content</h4>
+      <p>Lorem ipsum dolor sit amet</p>
+    </div>
+  </div>
+  <div class="sdv-modal-backdrop"></div>
+</div>
+
+<a href="#slideout">Open slideout</a>
 ```
 
 :::


### PR DESCRIPTION
The pseudo class is added next to the active state class. The active state class is also renamed to
-sdv-modal-active to avoid name collisions

BREAKING CHANGE: The active state css class has changed name from -active to -sdv-modal-active

fix #42