### PR TITLE
docs(modals): correct old import paths in modal examples

### DIFF
--- a/src/components/modals/modal-dialog.md
+++ b/src/components/modals/modal-dialog.md
@@ -103,7 +103,7 @@ Please note - the backdrop element has to be a child of the modal, like above (s
 2 - Use the modal-dialog mixin:
 
 ```scss
-@import '~@sebgroup/vanilla/src/components/modals/modal-mixins';
+@import '~@sebgroup/vanilla/src/components/modals/modal-dialog-mixins';
 
 .my-dialog-class {
   @include vanilla-modal-dialog();

--- a/src/components/modals/modal-slideout.md
+++ b/src/components/modals/modal-slideout.md
@@ -116,7 +116,7 @@ Please note - the backdrop element has to be a child of the modal, like above (s
 2 - Use the modal-slideout mixin:
 
 ```scss
-@import '~@sebgroup/vanilla/src/components/modals/slideout-mixins';
+@import '~@sebgroup/vanilla/src/components/modals/modal-slideout-mixins';
 
 .my-modal-class {
   @include vanilla-modal-slideout();


### PR DESCRIPTION
Fix for incorrect paths in documentation