### PR TITLE
fix(alerts): dont wrap after icons on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9391,8 +9391,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9413,14 +9412,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9435,20 +9432,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9565,8 +9559,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9578,7 +9571,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9593,7 +9585,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9601,14 +9592,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9627,7 +9616,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9708,8 +9696,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9721,7 +9708,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9807,8 +9793,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9844,7 +9829,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9864,7 +9848,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9908,14 +9891,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/components/alerts/_alert-ribbon-mixins.scss
+++ b/src/components/alerts/_alert-ribbon-mixins.scss
@@ -23,7 +23,8 @@
 
   @include media-context($vanilla-breakpoints) {
     @include media('<tablet') {
-      margin-top: 0.5em;
+      flex-basis: 0;
+      flex-grow: 1;
       margin-right: 0;
     }
   }
@@ -53,7 +54,8 @@
 ///
 /// @access public
 @mixin vanilla-alert-ribbon__icon() {
-  font-size: 1.4em;
+  font-size: 1em;
+  line-height: 1.5;
 }
 
 ///
@@ -69,7 +71,9 @@
     @include vanilla-alert-ribbon__button();
   }
 
-  .fal {
+  .fal,
+  .far,
+  .fas {
     @include vanilla-alert-ribbon__icon();
   }
 

--- a/src/components/alerts/alert-ribbon.md
+++ b/src/components/alerts/alert-ribbon.md
@@ -49,7 +49,7 @@ These will be explained in the examples section, below the component preview.
 
 ```html
 <div class="sdv-alert-ribbon sdv-alert-ribbon--talk" role="alert">
-    <i class="fal fa-exclamation-triangle sdv-icon-left"></i>
+    <i class="fas fa-info-square sdv-icon-left"></i>
     <p>Eftersom vi inte har kontaktuppgifter till dig kan vi inte meddela dig när ordern är behandlad. Uppdatera gärna dina kontaktuppgifter.</p>
     <button class="sdv-alert-ribbon__button">Uppdatera</button>
 </div>


### PR DESCRIPTION
Currently icons end up on its own row on mobile phones.
Also add support for regular and solid icons.

![](https://designlibrary.sebgroup.com/ImageVault/publishedmedia/np1d6mb17grqvh7k7k80/alarts_all_2019-09-09.png)

