### PR TITLE
fix(color): lint issue grey800 #333333 -> #333

### DIFF
--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -32,7 +32,7 @@ $vanilla-color-grey400: #cecece;
 $vanilla-color-grey500: #adadad;
 $vanilla-color-grey600: #868686;
 $vanilla-color-grey700: #494949;
-$vanilla-color-grey800: #333333;
+$vanilla-color-grey800: #333;
 $vanilla-color-grey900: #1a1a1a;
 
 // For backwards compatibility


### PR DESCRIPTION
Corrects error:

```
> stylelint src/**/*.scss

src/_colors.scss
 35:25  ×  Expected "#333333" to be "#333"   color-hex-length
```