### PR TITLE
feat(progress-bar): add determinate progress-bar

### DIFF
--- a/src/components/progress-bars/_progress-bar-mixins.scss
+++ b/src/components/progress-bars/_progress-bar-mixins.scss
@@ -15,13 +15,13 @@ $vanilla-progressbar-keyframes: 'sdv-progressbar-loading' !default;
 ///
 /// @access public
 @mixin vanilla-progress-bar() {
-  appearance: none;
+  appearance: none; // Clear <progress> style
   height: vanilla-px-to-rem(5);
   width: 100%;
   position: relative;
   overflow: hidden;
-  color: $vanilla-color-green;
-  border-width: 0;
+  color: $vanilla-color-green; // IE fallback for ::-ms-fill
+  border-width: 0; // Firefox adds border
   background-color: $vanilla-color-grey8;
 
   &::before {
@@ -51,7 +51,7 @@ $vanilla-progressbar-keyframes: 'sdv-progressbar-loading' !default;
 
   // Track
   &::-webkit-progress-bar {
-    background-color: $vanilla-color-grey200;
+    background-color: $vanilla-color-grey200; // Chrome does not respect parent background
   }
 
   @keyframes #{$vanilla-progressbar-keyframes} {

--- a/src/components/progress-bars/_progress-bar-mixins.scss
+++ b/src/components/progress-bars/_progress-bar-mixins.scss
@@ -15,10 +15,13 @@ $vanilla-progressbar-keyframes: 'sdv-progressbar-loading' !default;
 ///
 /// @access public
 @mixin vanilla-progress-bar() {
+  appearance: none;
   height: vanilla-px-to-rem(5);
   width: 100%;
   position: relative;
   overflow: hidden;
+  color: $vanilla-color-green;
+  border-width: 0;
   background-color: $vanilla-color-grey8;
 
   &::before {
@@ -30,6 +33,25 @@ $vanilla-progressbar-keyframes: 'sdv-progressbar-loading' !default;
     height: vanilla-px-to-rem(5);
     background-color: $vanilla-color-green;
     animation: #{$vanilla-progressbar-keyframes} 2s linear infinite;
+  }
+
+  // Progress (follow https://bugzilla.mozilla.org/show_bug.cgi?id=662351 for changes)
+  &::-webkit-progress-value {
+    background-color: transparent;
+  }
+
+  &::-moz-progress-bar {
+    background-color: transparent;
+  }
+
+  &::-ms-fill {
+    background-color: transparent;
+    border-width: 0;
+  }
+
+  // Track
+  &::-webkit-progress-bar {
+    background-color: $vanilla-color-grey200;
   }
 
   @keyframes #{$vanilla-progressbar-keyframes} {
@@ -57,5 +79,25 @@ $vanilla-progressbar-keyframes: 'sdv-progressbar-loading' !default;
     to {
       left: 100%;
     }
+  }
+}
+
+/// @access public
+@mixin vanilla-progress-bar--determinate() {
+  &::before {
+    content: none;
+  }
+
+  // Progress
+  &::-webkit-progress-value {
+    background-color: $vanilla-color-green;
+  }
+
+  &::-moz-progress-bar {
+    background-color: $vanilla-color-green;
+  }
+
+  &::-ms-fill {
+    background-color: $vanilla-color-green;
   }
 }

--- a/src/components/progress-bars/_progress-bar.scss
+++ b/src/components/progress-bars/_progress-bar.scss
@@ -3,5 +3,9 @@
 @include _vanilla-exports('vanilla-progress-bar') {
   .sdv-progress-bar {
     @include vanilla-progress-bar();
+
+    &[value] {
+      @include vanilla-progress-bar--determinate();
+    }
   }
 }

--- a/src/components/progress-bars/progress-bar-determinate.md
+++ b/src/components/progress-bars/progress-bar-determinate.md
@@ -1,0 +1,21 @@
+---
+title: Progress bar (determinate)
+componentid: component-progressbar
+variantid: default
+guid: component-progressbar-determinate
+private: false
+---
+# Usage
+Import classes:
+```scss
+@import "~@sebgroup/vanilla/src/components/progress-bars/progress-bar";
+```
+
+Must have a value attribute set for `<progress>` to be determinate, else use a `<div>` without value attribute for indeterminate.
+
+:::componentpreview
+## Base state
+```html
+<progress class="sdv-progress-bar" max="100" value="70"> 70% </progress>
+```
+:::

--- a/src/components/progress-bars/progress-bar.md
+++ b/src/components/progress-bars/progress-bar.md
@@ -11,6 +11,8 @@ Import classes:
 @import "~@sebgroup/vanilla/src/components/progress-bars/progress-bar";
 ```
 
+`<div>` must be used as firefox does not support animation or pseudo elements on the `<progress>` tags.
+
 :::componentpreview
 ## Base state
 ```html


### PR DESCRIPTION
Added a determinate progress bar style using the built-in`<progress>` tag and made sure it was cross-browser compatible. Unfortunately the original indeterminate progress bar isn't be supported in Firefox with the `<progress>` tag, so old method is still prefered using `<div>`. No breaking changes.