### PR TITLE
fix: correct include-media module paths

### DIFF
--- a/src/_typography-mixins.scss
+++ b/src/_typography-mixins.scss
@@ -6,7 +6,7 @@
 
 @import 'variables';
 @import 'colors';
-@import 'node_modules/include-media/dist/include-media';
+@import '~include-media/dist/include-media';
 
 $seb-font-path: $vanilla-font-basepath;
 

--- a/src/components/modals/_common.scss
+++ b/src/components/modals/_common.scss
@@ -3,7 +3,7 @@
 /// @author SEB Design Library
 ////
 
-@import 'node_modules/include-media/dist/include-media';
+@import '~include-media/dist/include-media';
 
 @import '../../utilities';
 @import '../../variables';


### PR DESCRIPTION
Corrected remaining
```scss
@import 'node_modules/include-media/dist/include-media';
```
to
```scss
@import '~include-media/dist/include-media';
```