### PR TITLE
Feature/segmented control

### DIFF
--- a/src/_vanilla-all.scss
+++ b/src/_vanilla-all.scss
@@ -30,6 +30,7 @@
 @import 'components/modals/modal-dialog';
 @import 'components/tooltips/tooltip-all';
 @import 'components/inputs/stepper';
+@import 'components/segmented-control/segmented-control';
 @import 'components/sticky-bars/sticky-bar';
 @import 'components/sliders/range-input';
 

--- a/src/components/segmented-control/_segmented-control-mixins.scss
+++ b/src/components/segmented-control/_segmented-control-mixins.scss
@@ -14,6 +14,23 @@
   grid-auto-flow: column;
   grid-auto-columns: 1fr;
 
+  input[type='checkbox'],
+  input[type='radio'] {
+    visibility: hidden;
+    position: absolute;
+  }
+
+  > *[aria-selected='true'],
+  input[type='checkbox']:checked + label,
+  input[type='radio']:checked + label {
+    background-color: $vanilla-color-component-selected;
+    border-color: $vanilla-color-component-selected;
+    color: $vanilla-color-white;
+  }
+
+  div,
+  span,
+  label,
   button {
     @include media-context($vanilla-breakpoints) {
       @include media('<tablet') {
@@ -22,12 +39,17 @@
     }
   }
 
+  > div,
+  > span,
+  > label,
   > button {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    background-clip: padding-box;
   }
 
+  div ~ div,
+  span ~ span,
+  label ~ label,
   button ~ button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
@@ -38,12 +60,4 @@
       border-bottom-right-radius: $vanilla-component-border-radius;
     }
   }
-}
-
-///
-/// @access public
-@mixin vanilla-segmented-control--active() {
-  background-color: $vanilla-color-component-selected;
-  border-color: $vanilla-color-component-selected;
-  color: $vanilla-color-white;
 }

--- a/src/components/segmented-control/_segmented-control-mixins.scss
+++ b/src/components/segmented-control/_segmented-control-mixins.scss
@@ -10,7 +10,7 @@
 ///
 /// @access public
 @mixin vanilla-segmented-control() {
-  display: grid;
+  display: inline-grid;
   grid-auto-flow: column;
   grid-auto-columns: 1fr;
 

--- a/src/components/segmented-control/_segmented-control-mixins.scss
+++ b/src/components/segmented-control/_segmented-control-mixins.scss
@@ -1,0 +1,49 @@
+////
+/// @group Component mixins
+/// @author SEB Design Library
+////
+@import '~include-media/dist/include-media';
+
+@import '../../variables';
+@import '../../colors';
+
+///
+/// @access public
+@mixin vanilla-segmented-control() {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+
+  button {
+    @include media-context($vanilla-breakpoints) {
+      @include media('<tablet') {
+        overflow: hidden;
+      }
+    }
+  }
+
+  > button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    background-clip: padding-box;
+  }
+
+  button ~ button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 0;
+
+    &:last-of-type {
+      border-top-right-radius: $vanilla-component-border-radius;
+      border-bottom-right-radius: $vanilla-component-border-radius;
+    }
+  }
+}
+
+///
+/// @access public
+@mixin vanilla-segmented-control--active() {
+  background-color: $vanilla-color-component-selected;
+  border-color: $vanilla-color-component-selected;
+  color: $vanilla-color-white;
+}

--- a/src/components/segmented-control/_segmented-control.scss
+++ b/src/components/segmented-control/_segmented-control.scss
@@ -2,8 +2,4 @@
 
 .sdv-segmented-control {
   @include vanilla-segmented-control();
-
-  &--active {
-    @include vanilla-segmented-control--active();
-  }
 }

--- a/src/components/segmented-control/_segmented-control.scss
+++ b/src/components/segmented-control/_segmented-control.scss
@@ -1,0 +1,9 @@
+@import 'segmented-control-mixins';
+
+.sdv-segmented-control {
+  @include vanilla-segmented-control();
+
+  &--active {
+    @include vanilla-segmented-control--active();
+  }
+}

--- a/src/components/segmented-control/segmented-control.md
+++ b/src/components/segmented-control/segmented-control.md
@@ -10,29 +10,42 @@ Import classes:
 ```scss
 @import "~@sebgroup/vanilla/src/components/segmented-control/segmented-control";
 ```
-
-Framework needed! This mixin only contains the styles for the segmented control. Actual behaviour needs to be implemented using a JS framework.
+Supports using radio buttons, checkboxes, divs/spans and/or buttons. Can also be used as a wrapper to group buttons.
+When not using any of the input elements, active state is applied using aria-selected attribute.
 
 :::componentpreview
 
-## Three button segment
-
+## Three segments using radio buttons
 ```html
-
   <div class="sdv-segmented-control">
-    <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
-    <button class="sdv-button sdv-button-secondary">Digipass</button>
-    <button class="sdv-button sdv-button-secondary">Bank ID on file</button>
+    <input type="radio" id="sdv-control-1" name="sdv-control">
+    <label for="sdv-control-1" class="sdv-button sdv-button-secondary">Mobile Bank ID</label>
+    <input type="radio" id="sdv-control-2" name="sdv-control">
+    <label for="sdv-control-2" class="sdv-button sdv-button-secondary">Digipass</label>
+    <input type="radio" id="sdv-control-3" name="sdv-control">
+    <label for="sdv-control-3" class="sdv-button sdv-button-secondary">Bank ID on file</label>
   </div>
-
 ```
 
-## Two button segment
+## Three segments using checkboxes
 ```html
-<div class="sdv-segmented-control">
-  <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
-  <button class="sdv-button sdv-button-secondary">Bank ID on file</button>
-</div>
+  <div class="sdv-segmented-control">
+    <input type="checkbox" id="sdv-control-1" name="sdv-control">
+    <label for="sdv-control-1" class="sdv-button sdv-button-secondary">Mobile Bank ID</label>
+    <input type="checkbox" id="sdv-control-2" name="sdv-control">
+    <label for="sdv-control-2" class="sdv-button sdv-button-secondary">Digipass</label>
+    <input type="checkbox" id="sdv-control-3" name="sdv-control">
+    <label for="sdv-control-3" class="sdv-button sdv-button-secondary">Bank ID on file</label>
+  </div>
+```
+
+## Three segments using div and aria-select
+```html
+  <div class="sdv-segmented-control">
+    <div class="sdv-button sdv-button-secondary">Mobile Bank ID</div>
+    <div class="sdv-button sdv-button-secondary">Digipass</div>
+    <div aria-selected="true" class="sdv-button sdv-button-secondary">Bank ID on file</div>
+  </div>
 ```
 
 ## Five button segment
@@ -46,22 +59,11 @@ Framework needed! This mixin only contains the styles for the segmented control.
 </div>
 ```
 
-## Small segment
+## Small two button segment
 ```html
 <div class="sdv-segmented-control">
-  <button class="sdv-button sdv-button--small sdv-button-secondary">Mobile Bank ID</button>
-  <button class="sdv-button sdv-button--small sdv-button-secondary">Digipass</button>
-  <button class="sdv-button sdv-button--small sdv-button-secondary">Bank ID on file</button>
-</div>
-```
-
-## Selected active segment
-
-```html
-<div class="sdv-segmented-control">
-  <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
-  <button class="sdv-button sdv-button-secondary sdv-segmented-control--active">Digipass</button>
-  <button class="sdv-button sdv-button-secondary">Bank ID on file</button>
+  <button class="sdv-button sdv-button--small sdv-button-secondary">Graph</button>
+  <button class="sdv-button sdv-button--small sdv-button-secondary">Diagram</button>
 </div>
 ```
 

--- a/src/components/segmented-control/segmented-control.md
+++ b/src/components/segmented-control/segmented-control.md
@@ -1,0 +1,76 @@
+---
+title: Segmented control
+componentid: component-segmented-control
+variantid: default
+guid: component-segmented-control-default
+---
+
+# Usage
+Import classes:
+```scss
+@import "~@sebgroup/vanilla/src/components/segmented-control/segmented-control";
+```
+
+Framework needed! This mixin only contains the styles for the segmented control. Actual behaviour needs to be implemented using a JS framework.
+
+:::componentpreview
+
+## Three button segment
+
+```html
+
+  <div class="sdv-segmented-control">
+    <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
+    <button class="sdv-button sdv-button-secondary">Digipass</button>
+    <button class="sdv-button sdv-button-secondary">Bank ID on file</button>
+  </div>
+
+```
+
+## Two button segment
+```html
+<div class="sdv-segmented-control">
+  <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
+  <button class="sdv-button sdv-button-secondary">Bank ID on file</button>
+</div>
+```
+
+## Five button segment
+```html
+<div class="sdv-segmented-control">
+  <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
+  <button class="sdv-button sdv-button-secondary">Digipass 1</button>
+  <button class="sdv-button sdv-button-secondary">Digipass 2</button>
+  <button class="sdv-button sdv-button-secondary">Digipass 3</button>
+  <button class="sdv-button sdv-button-secondary">Bank ID on file</button>
+</div>
+```
+
+## Small segment
+```html
+<div class="sdv-segmented-control">
+  <button class="sdv-button sdv-button--small sdv-button-secondary">Mobile Bank ID</button>
+  <button class="sdv-button sdv-button--small sdv-button-secondary">Digipass</button>
+  <button class="sdv-button sdv-button--small sdv-button-secondary">Bank ID on file</button>
+</div>
+```
+
+## Selected active segment
+
+```html
+<div class="sdv-segmented-control">
+  <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
+  <button class="sdv-button sdv-button-secondary sdv-segmented-control--active">Digipass</button>
+  <button class="sdv-button sdv-button-secondary">Bank ID on file</button>
+</div>
+```
+
+## Disabled segment
+```html
+<div class="sdv-segmented-control">
+  <button class="sdv-button sdv-button-secondary">Mobile Bank ID</button>
+  <button class="sdv-button sdv-button-secondary">Digipass</button>
+  <button disabled class="sdv-button sdv-button-secondary">Bank ID on file</button>
+</div>
+```
+:::


### PR DESCRIPTION
Based on https://designlibrary.sebgroup.com/components/segmented-control/

Implemented a wrapper class that displays button, radio button, checkbox, div and span elements within it as grid. Works with both `sdv-button` and `sdv-button-small`. On smaller screens, the buttons `overflow` is set to `hidden`.

Active state is based on the same styling as `vanilla-button-secondary:focus`/`:active`, and do not take into account which button classes the actual containing elements are using.
![sdv-segmented-control-implementation](https://user-images.githubusercontent.com/49610436/90882437-3fa6d680-e3ac-11ea-8bb8-74a3bc4dc0f9.PNG)
