### PR TITLE
feat: added list styling component

### DIFF
--- a/src/_vanilla-all.scss
+++ b/src/_vanilla-all.scss
@@ -34,6 +34,7 @@
 @import 'components/segmented-control/segmented-control';
 @import 'components/sticky-bars/sticky-bar';
 @import 'components/sliders/range-input';
+@import 'components/list/list';
 
 /// Deprecated
 @import 'components/dialogs/dialog';

--- a/src/components/list/_list-mixins.scss
+++ b/src/components/list/_list-mixins.scss
@@ -1,0 +1,111 @@
+////
+/// @group Component mixins
+/// @author SEB Design Library
+////
+@import '~include-media/dist/include-media';
+
+@import '../../variables';
+@import '../../colors';
+
+$vanilla_list_space: 1rem;
+
+///
+/// @access public
+@mixin vanilla-list() {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+
+  &__wrapper {
+    width: 100%;
+
+    label,
+    &__label {
+      @include vanilla-list-label();
+    }
+  }
+
+  label,
+  &__label {
+    @include vanilla-list-label();
+  }
+
+  li,
+  &__item {
+    @include vanilla-list-item();
+
+    dt,
+    &-label {
+      @include vanilla-list-item-label();
+    }
+
+    dd,
+    &-value {
+      @include vanilla-list-item-value();
+    }
+  }
+}
+
+@mixin vanilla-list-label() {
+  background-color: $vanilla-color-grey100;
+  display: block;
+  padding-left: $vanilla_list_space;
+  font-size: 14px;
+  line-height: 2rem;
+}
+
+@mixin vanilla-list-item() {
+  min-height: vanilla-px-to-em(40);
+  border-bottom: 1px solid $vanilla-color-grey200;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+
+  > * {
+    margin: 0;
+  }
+}
+
+@mixin vanilla-list-item-label() {
+  padding-left: $vanilla_list_space;
+}
+
+@mixin vanilla-list-item-value() {
+  justify-content: flex-end;
+  font-weight: 500;
+  text-align: right;
+  padding-right: $vanilla_list_space;
+
+  &--left {
+    text-align: left;
+    padding-left: $vanilla_list_space;
+    padding-right: 0;
+    justify-content: flex-start;
+  }
+}
+
+///
+/// @access public
+@mixin vanilla-list--small() {
+  li,
+  &__item {
+    display: block;
+
+    dt,
+    &-label {
+      line-height: 1rem;
+      padding-bottom: 0.5rem;
+      font-size: 14px;
+    }
+
+    dd,
+    &-value {
+      line-height: 1rem;
+      text-align: left;
+      padding-left: $vanilla_list_space;
+      padding-right: 0;
+    }
+  }
+}

--- a/src/components/list/_list-mixins.scss
+++ b/src/components/list/_list-mixins.scss
@@ -21,32 +21,32 @@ $vanilla_list_space: 1rem;
 
     label,
     &__label {
-      @include vanilla-list-label();
+      @include vanilla-list__label();
     }
   }
 
   label,
   &__label {
-    @include vanilla-list-label();
+    @include vanilla-list__label();
   }
 
   li,
   &__item {
-    @include vanilla-list-item();
+    @include vanilla-list__item();
 
     dt,
     &-label {
-      @include vanilla-list-item-label();
+      @include vanilla-list__item-label();
     }
 
     dd,
     &-value {
-      @include vanilla-list-item-value();
+      @include vanilla-list__item-value();
     }
   }
 }
 
-@mixin vanilla-list-label() {
+@mixin vanilla-list__label() {
   background-color: $vanilla-color-grey100;
   display: block;
   padding-left: $vanilla_list_space;
@@ -54,7 +54,7 @@ $vanilla_list_space: 1rem;
   line-height: 2rem;
 }
 
-@mixin vanilla-list-item() {
+@mixin vanilla-list__item() {
   min-height: vanilla-px-to-em(40);
   border-bottom: 1px solid $vanilla-color-grey200;
   display: flex;
@@ -68,11 +68,11 @@ $vanilla_list_space: 1rem;
   }
 }
 
-@mixin vanilla-list-item-label() {
+@mixin vanilla-list__item-label() {
   padding-left: $vanilla_list_space;
 }
 
-@mixin vanilla-list-item-value() {
+@mixin vanilla-list__item-value() {
   justify-content: flex-end;
   font-weight: 500;
   text-align: right;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,0 +1,11 @@
+@import './list-mixins';
+
+@include _vanilla-exports('vanilla-list') {
+  .sdv-list {
+    @include vanilla-list();
+  }
+
+  .sdv-list--small {
+    @include vanilla-list--small();
+  }
+}

--- a/src/components/list/list.md
+++ b/src/components/list/list.md
@@ -1,0 +1,102 @@
+---
+title: List
+componentid: component-list
+variantid: default
+guid: component-list-default
+---
+
+# Usage
+Import classes:
+```scss
+@import "~@sebgroup/vanilla/src/components/list/list";
+```
+Supports ul, dl and div elements as lists. The wrapper is not strictly necessary if the parent element does not use 'display: flex'. If the wrapper is not used, the gray label gets its styling by applying the 'sdv-list__label'-class.
+
+By default, all text in the value-column is right-aligned. This can be overwritten by using the 'sdv-list__item-value--left'-class.
+
+For smaller screens, sdv-list--small can be used in order to place the label above the value.
+
+:::componentpreview
+
+## Using ul
+```html
+<div class="sdv-list__wrapper">
+  <label class="sdv-list__label">Label</label>
+  <ul class="sdv-list">
+    <li>
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </li>
+    <li>
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </li>
+  </ul>
+  <label class="sdv-list-label">Label</label>
+  <ul class="sdv-list">
+    <li>
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </li>
+    <li>
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </li>
+  </ul>
+</div>
+```
+## Using dl and wrapper
+```html
+<div class="sdv-list__wrapper">
+  <label>Label</label>
+  <dl class="sdv-list">
+    <div class="sdv-list__item">
+      <dt>Label, 16px regular</dt>
+      <dd>Value, 16px medium</dd>
+    </div>
+    <div class="sdv-list__item">
+      <dt>Label, 16px regular</dt>
+      <dd>Value, 16px medium</dd>
+    </div>
+  </dl>
+  <label>Label</label>
+  <dl class="sdv-list">
+    <div class="sdv-list__item">
+      <dt>Label, 16px regular</dt>
+      <dd>Value, 16px medium</dd>
+    </div>
+    <div class="sdv-list__item">
+      <dt>Label, 16px regular</dt>
+      <dd>Value, 16px medium</dd>
+    </div>
+  </dl>
+</div>
+```
+## Using block elements
+```html
+<div class="sdv-list__wrapper">
+  <label>Label</label>
+  <div class="sdv-list">
+    <div class="sdv-list__item">
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </div>
+    <div class="sdv-list__item">
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </div>
+  </div>
+  <label>Label</label>
+  <div class="sdv-list">
+    <div class="sdv-list__item">
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </div>
+    <div class="sdv-list__item">
+      <div class="sdv-list__item-label">Label, 16px regular</div>
+      <div class="sdv-list__item-value">Value, 16px medium</div>
+    </div>
+  </div>
+</div>
+```
+:::


### PR DESCRIPTION
Based off of the concept images from https://designlibrary.sebgroup.com/components/list-components/list/#guidelines.

List styling for ul, dl and divs. Basically adds some help in order to create right-aligned values in a list-item.

![sdv-list-implementation](https://user-images.githubusercontent.com/49610436/95089438-6fbff400-0724-11eb-8730-a6cdbb176009.PNG)