### PR TITLE
fix: change box-shadow style for focus state

### DIFF
--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -61,8 +61,8 @@
 /// Add focus outline to element
 ///
 /// @access public
-@mixin vanilla-focus-outline() {
-  box-shadow: 0 0 0 3px rgba($vanilla-color-component-selected, 0.2);
+@mixin vanilla-focus-outline($shadow-color: $vanilla-color-blue, $opacity: 1) {
+  box-shadow: 0 0 4px 1px rgba($shadow-color, $opacity);
   transition: box-shadow 250ms;
 }
 

--- a/src/components/buttons/_button-mixins.scss
+++ b/src/components/buttons/_button-mixins.scss
@@ -176,6 +176,10 @@ $_ghost-button_disabled-opacity: 0.5;
   color: $vanilla-color-white;
   background-color: transparent;
 
+  &:focus {
+    @include vanilla-focus-outline($vanilla-color-white, 0.9);
+  }
+
   &:focus,
   &:hover,
   &:active {
@@ -198,6 +202,10 @@ $_ghost-button_disabled-opacity: 0.5;
   border-color: $vanilla-color-grey2;
   color: $vanilla-color-grey2;
   background-color: transparent;
+
+  &:focus {
+    @include vanilla-focus-outline($vanilla-color-grey700);
+  }
 
   &:focus,
   &:hover,
@@ -230,6 +238,10 @@ $_ghost-button_disabled-opacity: 0.5;
   background-color: transparent;
   border-color: transparent;
 
+  &:focus {
+    @include vanilla-focus-outline($vanilla-color-red);
+  }
+
   &:focus,
   &:hover,
   &:active {
@@ -252,6 +264,10 @@ $_ghost-button_disabled-opacity: 0.5;
   color: $vanilla-color-white;
   background-color: $vanilla-color-darkred1;
   border-color: $vanilla-color-darkred1;
+
+  &:focus {
+    @include vanilla-focus-outline($vanilla-color-red);
+  }
 
   &:focus,
   &:hover,


### PR DESCRIPTION
Fix #216 
Updated box-shadow styling for the global mixin for focus outline.
The changes affect all interactive elements. 
![Input field](https://user-images.githubusercontent.com/28731111/100440783-b4716700-30a5-11eb-960c-683cdb5dd5d2.PNG)
![primary](https://user-images.githubusercontent.com/28731111/100440791-b89d8480-30a5-11eb-9194-784b2b32c694.PNG)


In order to support the red focus outline (shown in the images in #216 )
vanilla-focus-outline mixin also accepts two optional parameters for setting box-shadow color and opacity. State colors for buttons have not been updated according to specifications, and will hence look a little "fuzzy". 
![delete](https://user-images.githubusercontent.com/28731111/100440935-f1d5f480-30a5-11eb-902c-d4445c338a33.PNG)

An unexpected effect is that the blue box-shadow clashed with non-blue buttons. To mitigate this, a solution similar to the red outline was implemented for ghost buttons. There is no concept art for this, so this needs to be re-iterated. 
![ghost dark](https://user-images.githubusercontent.com/28731111/100441257-77f23b00-30a6-11eb-9333-2edd1a23983b.PNG)
![ghost light](https://user-images.githubusercontent.com/28731111/100441268-7b85c200-30a6-11eb-83c3-b8edfb0f59a5.PNG)

