### PR TITLE
refactor(tooltip): split arrow style from pseudo

### DIFF
--- a/src/components/tooltips/_tooltip-mixins.scss
+++ b/src/components/tooltips/_tooltip-mixins.scss
@@ -28,93 +28,81 @@ $vanilla-tooltip-bg-color: $vanilla-color-grey1;
 ///
 /// @access public
 @mixin vanilla-tooltip-arrow {
+  position: absolute;
   width: 0;
   height: 0;
-  border: vanilla-px-to-rem(8) solid $vanilla-tooltip-bg-color;
-}
-
-/// Styles for default tooltip class
-///
-/// @access public
-@mixin vanilla-tooltip__main() {
-  @include vanilla-tooltip-box();
-  position: relative;
-
-  &::after {
-    @include vanilla-tooltip-arrow();
-    content: '';
-    position: absolute;
-  }
-}
-
-/// Styles for default tooltip class
-///
-/// @access public
-@mixin vanilla-tooltip() {
-  @include vanilla-tooltip__main();
-
-  &--top {
-    @include vanilla-tooltip--top();
-  }
-
-  &--bottom {
-    @include vanilla-tooltip--bottom();
-  }
-
-  &--left {
-    @include vanilla-tooltip--left();
-  }
-
-  &--right {
-    @include vanilla-tooltip--right();
-  }
+  border: vanilla-px-to-rem(8) solid transparent;
 }
 
 /// Tooltip top modifier
 ///
 /// @access public
 @mixin vanilla-tooltip--top() {
-  &::after {
-    bottom: vanilla-px-to-rem(-16);
-    left: 50%;
-    transform: translateX(-50%);
-    border-color: $vanilla-tooltip-bg-color transparent transparent;
-  }
+  @include vanilla-tooltip-arrow();
+  bottom: vanilla-px-to-rem(-16);
+  left: 50%;
+  transform: translateX(-50%);
+  border-color: $vanilla-tooltip-bg-color transparent transparent;
 }
 
 /// Tooltip bottom modifier
 ///
 /// @access public
 @mixin vanilla-tooltip--bottom() {
-  &::after {
-    top: vanilla-px-to-rem(-16);
-    left: 50%;
-    transform: translateX(-50%);
-    border-color: transparent transparent $vanilla-tooltip-bg-color;
-  }
+  @include vanilla-tooltip-arrow();
+  top: vanilla-px-to-rem(-16);
+  left: 50%;
+  transform: translateX(-50%);
+  border-color: transparent transparent $vanilla-tooltip-bg-color;
 }
 
 /// Tooltip left modifier
 ///
 /// @access public
 @mixin vanilla-tooltip--left() {
-  &::after {
-    left: vanilla-px-to-rem(-16);
-    top: 50%;
-    transform: translateY(-50%);
-    border-color: transparent $vanilla-tooltip-bg-color transparent transparent;
-  }
+  @include vanilla-tooltip-arrow();
+  right: vanilla-px-to-rem(-16);
+  top: 50%;
+  transform: translateY(-50%);
+  border-color: transparent transparent transparent $vanilla-tooltip-bg-color;
 }
 
 /// Tooltip right modifier
 ///
 /// @access public
 @mixin vanilla-tooltip--right() {
-  &::after {
-    right: vanilla-px-to-rem(-16);
-    top: 50%;
-    transform: translateY(-50%);
-    border-color: transparent transparent transparent $vanilla-tooltip-bg-color;
+  @include vanilla-tooltip-arrow();
+  left: vanilla-px-to-rem(-16);
+  top: 50%;
+  transform: translateY(-50%);
+  border-color: transparent $vanilla-tooltip-bg-color transparent transparent;
+}
+
+/// Styles for default tooltip class
+///
+/// @access public
+@mixin vanilla-tooltip() {
+  @include vanilla-tooltip-box();
+  position: relative;
+
+  &--top::after {
+    @include vanilla-tooltip--top();
+    content: '';
+  }
+
+  &--bottom::after {
+    @include vanilla-tooltip--bottom();
+    content: '';
+  }
+
+  &--left::after {
+    @include vanilla-tooltip--left();
+    content: '';
+  }
+
+  &--right::after {
+    @include vanilla-tooltip--right();
+    content: '';
   }
 }
 

--- a/src/components/tooltips/_tooltip.scss
+++ b/src/components/tooltips/_tooltip.scss
@@ -3,5 +3,21 @@
 @include _vanilla-exports('vanilla-tooltip') {
   .sdv-tooltip {
     @include vanilla-tooltip();
+
+    &__arrow-top {
+      @include vanilla-tooltip--top();
+    }
+
+    &__arrow-bottom {
+      @include vanilla-tooltip--bottom();
+    }
+
+    &__arrow-left {
+      @include vanilla-tooltip--left();
+    }
+
+    &__arrow-right {
+      @include vanilla-tooltip--right();
+    }
   }
 }

--- a/src/components/tooltips/tooltip.md
+++ b/src/components/tooltips/tooltip.md
@@ -13,7 +13,7 @@ Import classes:
 @import 'vanilla/components/tooltips/tooltip';
 ```
 
-Framework needed! This contains only the styles for a tooltip. Behaviour and positioning needs to be implemented in a JS framework.
+Framework needed! This contains only the styles for a tooltip. Behaviour and positioning needs to be implemented in a JS framework. To manipulate arrow positioning and styling of through Javascript, use the adjustable version under "Show details".
 
 If you only need a simple tooltip positioned above the text/icon, take a look at the CSS-only variant of the tooltip. It is more limited, but does not require any Javascript to work.
 
@@ -28,9 +28,7 @@ If you only need a simple tooltip positioned above the text/icon, take a look at
 ## Bottom
 
 ```html
-<div tabindex="0" class="sdv-tooltip sdv-tooltip--bottom">
-  This is a tooltip
-</div>
+<div tabindex="0" class="sdv-tooltip sdv-tooltip--bottom">This is a tooltip</div>
 ```
 
 ## Left
@@ -43,6 +41,30 @@ If you only need a simple tooltip positioned above the text/icon, take a look at
 
 ```html
 <div tabindex="0" class="sdv-tooltip sdv-tooltip--right">This is a tooltip</div>
+```
+
+## Top Adjustable Arrow
+
+```html
+<div tabindex="0" class="sdv-tooltip">This is a tooltip<div class="sdv-tooltip__arrow-top"></div></div>
+```
+
+## Bottom Adjustable Arrow
+
+```html
+<div tabindex="0" class="sdv-tooltip">This is a tooltip<div class="sdv-tooltip__arrow-bottom"></div></div>
+```
+
+## Left Adjustable Arrow
+
+```html
+<div tabindex="0" class="sdv-tooltip">This is a tooltip<div class="sdv-tooltip__arrow-left"></div></div>
+```
+
+## Right Adjustable Arrow
+
+```html
+<div tabindex="0" class="sdv-tooltip">This is a tooltip<div class="sdv-tooltip__arrow-right"></div></div>
 ```
 
 :::

--- a/src/test/tooltips/tooltip.spec.scss
+++ b/src/test/tooltips/tooltip.spec.scss
@@ -21,26 +21,6 @@
       }
     }
   }
-  @include it('Should compile vanilla-tooltip__main') {
-    @include assert {
-      @include output {
-        @include vanilla-tooltip__main();
-      }
-      @include expect {
-        @include vanilla-tooltip__main();
-      }
-    }
-  }
-  @include it('Should compile vanilla-tooltip') {
-    @include assert {
-      @include output {
-        @include vanilla-tooltip();
-      }
-      @include expect {
-        @include vanilla-tooltip();
-      }
-    }
-  }
   @include it('Should compile vanilla-tooltip--top') {
     @include assert {
       @include output {
@@ -78,6 +58,16 @@
       }
       @include expect {
         @include vanilla-tooltip--right();
+      }
+    }
+  }
+  @include it('Should compile vanilla-tooltip') {
+    @include assert {
+      @include output {
+        @include vanilla-tooltip();
+      }
+      @include expect {
+        @include vanilla-tooltip();
       }
     }
   }


### PR DESCRIPTION
* removed the need to use pseudo element for arrows
* added new classes for "nested/adjustable" arrow styling
* flipped left and right to match top and bottom

BREAKING CHANGES: flipped left and right, removed obsolete mixin vanilla-tooltip__main