### PR TITLE
feat: appending content (e.g. icons) in input-fields

### DIFF
--- a/src/components/inputs/_input_base.scss
+++ b/src/components/inputs/_input_base.scss
@@ -30,6 +30,14 @@
     @include vanilla-text-field-notice--error();
   }
 
+  .sdv-field-wrap {
+    @include vanilla-text-field-wrap();
+
+    .sdv-field__after {
+      @include vanilla-text-field__after();
+    }
+  }
+
   textarea.sdv-field {
     @include vanilla-text-field-textarea();
   }

--- a/src/components/inputs/_text-field-mixins.scss
+++ b/src/components/inputs/_text-field-mixins.scss
@@ -63,3 +63,32 @@
 @mixin vanilla-text-field-label() {
   @include vanilla-field-label();
 }
+
+/// Style for input wrap. This is meant to be applied to elements that
+/// contain both an input and other content.
+///
+/// @access public
+@mixin vanilla-text-field-wrap() {
+  position: relative;
+  height: vanilla-px-to-em(44px);
+}
+
+/// Style for icons and text appended to the right in the input-field
+///
+/// @access public
+@mixin vanilla-text-field__after() {
+  $_width: 2.5rem;
+
+  width: $_width;
+  height: 100%;
+  position: absolute;
+  right: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  // supported in ie9+
+  &:not(:empty) + .sdv-field {
+    padding-right: $_width;
+  }
+}

--- a/src/components/inputs/default.md
+++ b/src/components/inputs/default.md
@@ -74,6 +74,23 @@ In addition to the classes shown in the example below, this component can be use
 </div>
 ```
 
+## With text or icon appended
+
+```html
+<div>
+  <label for="input-field" class="sdv-field-label">Field label</label>
+  <div class="sdv-field-wrap">
+    <span class="sdv-field__after">SEK</span>
+    <input
+      id="input-field"
+      class="sdv-field"
+      aria-label="Field label"
+      placeholder="Input field"
+    />
+  </div>
+</div>
+```
+
 ## Small version
 
 ```html


### PR DESCRIPTION
Added wrapper class to make it easier to add icons and other content at the end of input fields. Measures are based on following specification: [Input_fields_2020-09-11.png](https://designlibrary.sebgroup.com/ImageVault/publishedmedia/v529uwxspg07z4jpkfqq/Input_fields_2020-09-11.png).

![sdv-input with icon](https://user-images.githubusercontent.com/49610436/100459885-7fc1d780-30c6-11eb-8940-08916b1d777f.png)

To use it, the input field needs to be wrapped in a block element using the class `.sdv-field-wrap`. The content to append needs to be wrapped in an element using the class `.sdv-field__after`. The content wrapper needs then to be placed before the input element in the dom. Se following example:
```
<div class="sdv-field-wrap">
  <span class="sdv-field__after"><!-- place content or icon to append here --></span>
  <input class="sdv-field" />
</div>
```
The order is used in order to avoid adding padding to the input field should the `sdv-field__after` element be empty.

Updated default.md with example.