### PR TITLE
fix(modal): avoid triggering active state when nested in active parent

### DIFF
--- a/src/components/modals/_common.scss
+++ b/src/components/modals/_common.scss
@@ -52,12 +52,12 @@ $vanilla-modal-active-state-class: -active !default;
   width: 100vw;
   height: 100vh;
 
-  .#{$vanilla-modal-active-state-class} & {
+  .#{$vanilla-modal-active-state-class} > & {
     background-color: $background-color;
     visibility: visible;
   }
   @if ($use-target-pseudo-class-for-active-state == true) {
-    :target & {
+    :target > & {
       background-color: $background-color;
       visibility: visible;
     }

--- a/src/components/modals/_modal-dialog-mixins.scss
+++ b/src/components/modals/_modal-dialog-mixins.scss
@@ -82,7 +82,7 @@
   &.#{$vanilla-modal-active-state-class} {
     @include vanilla-modal--active();
 
-    #{$__module}__container {
+    > #{$__module}__container {
       @include vanilla-modal-dialog__container--active();
     }
   }
@@ -90,7 +90,7 @@
     &:target {
       @include vanilla-modal--active();
 
-      #{$__module}__container {
+      > #{$__module}__container {
         @include vanilla-modal-dialog__container--active();
       }
     }

--- a/src/components/modals/_modal-slideout-mixins.scss
+++ b/src/components/modals/_modal-slideout-mixins.scss
@@ -102,7 +102,7 @@
   &.#{$vanilla-modal-active-state-class} {
     @include vanilla-modal--active();
 
-    #{$__module}__container {
+    > #{$__module}__container {
       @include vanilla-modal-slideout__container--active();
     }
   }
@@ -110,7 +110,7 @@
     &:target {
       @include vanilla-modal--active();
 
-      #{$__module}__container {
+      > #{$__module}__container {
         @include vanilla-modal-slideout__container--active();
       }
     }


### PR DESCRIPTION
Today if a modal i nested inside for example a tab that has the class `-active` the modal will trigger as well. This pull-request addresses that issue by making the selector more strict. It has also been verified locally.